### PR TITLE
fix: stop state being shared between instances of the widget

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,8 @@
 <script setup lang="ts">
 import TheAddressWidget from '@/components/TheAddressWidget.vue';
 import {useProvideAddressApi} from '@/composables/useAddressApi';
-import {useProvideConfig, useProvideAddressData} from '@/main';
+import {useProvideAddressData} from '@/composables/useAddressData';
+import {useProvideConfig} from '@/composables/useConfig';
 // Provide global injection states, sharing data between components
 useProvideConfig();
 useProvideAddressData();

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,16 @@
-<script setup lang="ts">
-import TheAddressWidget from '@/components/TheAddressWidget.vue';
-</script>
-
 <template>
   <TheAddressWidget />
 </template>
+
+<script setup lang="ts">
+import TheAddressWidget from '@/components/TheAddressWidget.vue';
+import {useProvideAddressApi} from '@/composables/useAddressApi';
+import {useProvideConfig, useProvideAddressData} from '@/main';
+// Provide global injection states, sharing data between components
+useProvideConfig();
+useProvideAddressData();
+useProvideAddressApi();
+</script>
 
 <style>
 @import '@/styles/base.css';

--- a/src/DemoApp.vue
+++ b/src/DemoApp.vue
@@ -18,7 +18,7 @@
   </section>
 
   <section class="p-4 flex flex-col space-y-4 max-w-80">
-    <TheAddressWidget />
+    <TheAddressWidget :config="configFromJson" />
   </section>
 
   <section>
@@ -31,22 +31,21 @@
 
 <script setup="context" lang="ts">
 import './styles/base.css';
-import {ref, toValue, watch} from 'vue';
+import {computed, ref, type ComputedRef} from 'vue';
 import TheAddressWidget from './components/TheAddressWidget.vue';
-import {useAddressData} from './composables/useAddressData';
-import {useConfig} from './composables/useConfig';
+import {useProvideAddressData} from './composables/useAddressData';
+import {useProvideConfig, type ConfigObject} from './composables/useConfig';
 import BaseTextArea from './components/Base/BaseTextArea.vue';
+import {useProvideAddressApi} from '@/composables/useAddressApi';
 
-const {configuration, setConfig} = useConfig();
+// Provide global injection states, sharing data between components
+const {configuration} = useProvideConfig();
+const {selectedAddress} = useProvideAddressData();
+useProvideAddressApi();
+
 const configAsJson = ref(JSON.stringify(configuration, null, 2));
-watch(configAsJson, (newVal) => {
-  try {
-    const parsed = JSON.parse(toValue(newVal));
-    setConfig(parsed);
-  } catch (e) {
-    console.error(e);
-  }
-});
 
-const selectedAddress = useAddressData().selectedAddress;
+const configFromJson: ComputedRef<ConfigObject> = computed(() => {
+  return JSON.parse(configAsJson.value);
+});
 </script>

--- a/src/composables/useAddressApi.ts
+++ b/src/composables/useAddressApi.ts
@@ -6,143 +6,145 @@ import {
   getAddresses,
 } from '@/api-client';
 import {ref, toValue, watch, type MaybeRefOrGetter, type Ref} from 'vue';
+import {createInjectionState} from '@vueuse/core';
+
 import {useApiClient} from './useApiClient';
 import {useAddressData} from './useAddressData';
+import {useOrThrow} from '@/utils/useOrThrow';
 
 const ABORT_REASON = new Error('Request cancelled because of new input');
-
-// State
-const addressResults: Ref<Address[] | undefined> = ref();
-const loading = ref(false);
-const abortController: Ref<AbortController | undefined> = ref();
 
 /**
  * Provides reactive state and wrapper functions for the address API SDK.
  */
-export function useAddressApi() {
-  const {countryCode} = useAddressData();
-
-  // Methods
-  const isProblemDetailsBadRequest = (
-    error: unknown,
-  ): error is ProblemDetailsBadRequest => {
-    if (typeof error !== 'object' || error === null) {
-      return false;
-    }
-
-    const problemDetails = error as ProblemDetailsBadRequest;
-    return (
-      problemDetails.type === 'urn:problem:validation-error' &&
-      problemDetails.status === 400 &&
-      Array.isArray(problemDetails.errors)
-    );
-  };
-
-  /**
-   * Clear any API results and loading state.
-   */
-  const resetState = () => {
-    addressResults.value = undefined;
-    loading.value = false;
-  };
-
-  /**
-   * Request address by postal code and house number.
-   *
-   * @param postalCode
-   * @param houseNumber
-   * @param countryCode
-   * @param houseNumberSuffix
-   */
-  const fetchAddressByPostalCode = async (
-    postalCode: MaybeRefOrGetter<string>,
-    houseNumber: MaybeRefOrGetter<string>,
-    countryCode: MaybeRefOrGetter<Alpha2CountryCode>,
-    houseNumberSuffix?: MaybeRefOrGetter<string>,
-  ) => {
-    // Postal code lookup is only supported for the Netherlands at this moment
-    if (toValue(countryCode) !== 'NL') {
-      throw new Error(
-        'Postal code lookup is only supported for the Netherlands', // @TODO translate
-      );
-    }
-
-    const params: GetAddressesData = {
-      query: {
-        postalCode: toValue(postalCode) || '',
-        houseNumber: toValue(houseNumber) || '',
-        houseNumberSuffix: toValue(houseNumberSuffix)?.length
-          ? toValue(houseNumberSuffix)
-          : undefined,
-        countryCode: toValue(countryCode),
-      },
-      url: '/addresses',
-    };
-
-    return await getAddressesWithErrorHandling(params);
-  };
-
-  /**
-   * Call the SDK `getAdresses` with standardized error handling and request aborts.
-   */
-  const getAddressesWithErrorHandling = async (
-    params: GetAddressesData,
-    silentAbort: boolean = true,
-  ) => {
+export const [useProvideAddressApi, useAddressApi] = createInjectionState(
+  () => {
+    const addressResults: Ref<Address[] | undefined> = ref();
+    const loading = ref(false);
+    const abortController: Ref<AbortController | undefined> = ref();
+    const {countryCode} = useOrThrow(useAddressData, 'useAddressData');
     const {client} = useApiClient();
 
-    // Abort any existing requests and create a new controller
-    abortController.value?.abort(ABORT_REASON);
-    abortController.value = new AbortController();
+    // Methods
+    const isProblemDetailsBadRequest = (
+      error: unknown,
+    ): error is ProblemDetailsBadRequest => {
+      if (typeof error !== 'object' || error === null) {
+        return false;
+      }
 
-    try {
-      loading.value = true;
-      const {error, response, data} = await getAddresses({
-        client,
-        ...params,
-        signal: abortController.value?.signal,
-      });
+      const problemDetails = error as ProblemDetailsBadRequest;
+      return (
+        problemDetails.type === 'urn:problem:validation-error' &&
+        problemDetails.status === 400 &&
+        Array.isArray(problemDetails.errors)
+      );
+    };
+
+    /**
+     * Clear any API results and loading state.
+     */
+    const resetState = () => {
+      addressResults.value = undefined;
       loading.value = false;
+    };
 
-      // Throw an error if the request didn't error but returned an error object.
-      if (error) {
+    /**
+     * Request address by postal code and house number.
+     *
+     * @param postalCode
+     * @param houseNumber
+     * @param countryCode
+     * @param houseNumberSuffix
+     */
+    const fetchAddressByPostalCode = async (
+      postalCode: MaybeRefOrGetter<string>,
+      houseNumber: MaybeRefOrGetter<string>,
+      countryCode: MaybeRefOrGetter<Alpha2CountryCode>,
+      houseNumberSuffix?: MaybeRefOrGetter<string>,
+    ) => {
+      // Postal code lookup is only supported for the Netherlands at this moment
+      if (toValue(countryCode) !== 'NL') {
+        throw new Error(
+          'Postal code lookup is only supported for the Netherlands', // @TODO translate
+        );
+      }
+
+      const params: GetAddressesData = {
+        query: {
+          postalCode: toValue(postalCode) || '',
+          houseNumber: toValue(houseNumber) || '',
+          houseNumberSuffix: toValue(houseNumberSuffix)?.length
+            ? toValue(houseNumberSuffix)
+            : undefined,
+          countryCode: toValue(countryCode),
+        },
+        url: '/addresses',
+      };
+
+      return await getAddressesWithErrorHandling(params);
+    };
+
+    /**
+     * Call the SDK `getAdresses` with standardized error handling and request aborts.
+     */
+    const getAddressesWithErrorHandling = async (
+      params: GetAddressesData,
+      silentAbort: boolean = true,
+    ) => {
+      // Abort any existing requests and create a new controller
+      abortController.value?.abort(ABORT_REASON);
+      abortController.value = new AbortController();
+
+      try {
+        loading.value = true;
+        const {error, response, data} = await getAddresses({
+          client,
+          ...params,
+          signal: abortController.value?.signal,
+        });
+        loading.value = false;
+
+        // Throw an error if the request didn't error but returned an error object.
+        if (error) {
+          throw error;
+        }
+
+        // If the request didn't error but the response was not ok, throw an error.
+        if (!response.ok) {
+          throw new Error('Failed to fetch address'); // @TODO translate
+        }
+
+        addressResults.value = data.results;
+      } catch (error) {
+        // Catch to reset loading state and rethrow
+        loading.value = false;
+
+        // Ignore the error if the request was aborted by us.
+        if (silentAbort && error === ABORT_REASON) {
+          console.debug(
+            'Request was aborted because it did not finish in time for new input.',
+          );
+          return;
+        }
         throw error;
       }
+    };
 
-      // If the request didn't error but the response was not ok, throw an error.
-      if (!response.ok) {
-        throw new Error('Failed to fetch address'); // @TODO translate
-      }
+    /**
+     * Reset most of the API state when the country changes.
+     */
+    watch(countryCode, () => {
+      resetState();
+    });
 
-      addressResults.value = data.results;
-    } catch (error) {
-      // Catch to reset loading state and rethrow
-      loading.value = false;
-
-      // Ignore the error if the request was aborted by us.
-      if (silentAbort && error === ABORT_REASON) {
-        console.debug(
-          'Request was aborted because it did not finish in time for new input.',
-        );
-        return;
-      }
-      throw error;
-    }
-  };
-
-  /**
-   * Reset most of the API state when the country changes.
-   */
-  watch(countryCode, () => {
-    resetState();
-  });
-
-  return {
-    addressResults,
-    loading,
-    isProblemDetailsBadRequest,
-    resetState,
-    fetchAddressByPostalCode,
-    getAddressesWithErrorHandling,
-  };
-}
+    return {
+      addressResults,
+      loading,
+      isProblemDetailsBadRequest,
+      resetState,
+      fetchAddressByPostalCode,
+      getAddressesWithErrorHandling,
+    };
+  },
+);

--- a/src/composables/useAddressData.spec.ts
+++ b/src/composables/useAddressData.spec.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, beforeEach, vi} from 'vitest';
+import {describe, it, expect, beforeEach} from 'vitest';
 import {useProvideAddressData} from './useAddressData';
 import type {Address} from '@/api-client/types.gen';
 import {withSetup} from '../../tests/withSetup';

--- a/src/composables/useAddressData.spec.ts
+++ b/src/composables/useAddressData.spec.ts
@@ -1,15 +1,14 @@
 import {describe, it, expect, beforeEach, vi} from 'vitest';
-import {useAddressData} from '@/composables/useAddressData';
+import {useProvideAddressData} from './useAddressData';
 import type {Address} from '@/api-client/types.gen';
+import {withSetup} from '../../tests/withSetup';
+import {useProvideConfig} from './useConfig';
 
 describe('useAddressData', () => {
-  let addressData: ReturnType<typeof useAddressData>;
-  const mockEmit = vi.fn();
+  let addressData: ReturnType<typeof useProvideAddressData>;
 
   beforeEach(() => {
-    vi.spyOn(document, 'dispatchEvent');
-
-    addressData = useAddressData(mockEmit);
+    [[, addressData]] = withSetup(useProvideConfig, useProvideAddressData);
     addressData.doReset();
   });
 
@@ -53,21 +52,6 @@ describe('useAddressData', () => {
     expect(addressData.street.value).toBe(address.street);
     expect(addressData.city.value).toBe(address.city);
     expect(selectedAddress.value).toStrictEqual(address);
-  });
-
-  it('should emit an event when selecting an address', () => {
-    const address: Address = {
-      postalCode: '1234AB',
-      houseNumber: '1',
-      houseNumberSuffix: 'A',
-      street: 'Main St',
-      city: 'Amsterdam',
-    };
-    addressData.selectAddress(address);
-    expect(mockEmit).toHaveBeenCalledWith('address-selected', address);
-    // Check for the window event
-    const event = new CustomEvent('address-selected', {detail: address});
-    expect(document.dispatchEvent).toHaveBeenCalledWith(event);
   });
 
   it('should check if we have all the required data for a postal code lookup', () => {

--- a/src/composables/useAddressData.ts
+++ b/src/composables/useAddressData.ts
@@ -2,129 +2,109 @@ import type {Alpha2CountryCode} from '@/api-client';
 import type {Address} from '@/api-client/types.gen';
 import {computed, ref, toValue, watch, type Ref} from 'vue';
 import type {ProblemDetailsBadRequest} from '@/api-client/types.gen';
+import {createInjectionState} from '@vueuse/core';
+import {useOrThrow} from '@/utils/useOrThrow';
 import {useConfig} from './useConfig';
 
 const POSTAL_CODE_MIN_LENGTH = 6; // eg. 1111AA - only relevant for NL postal codes at this point
-export const ADDRESS_SELECTED_EVENT = 'address-selected';
-export type AddressSelectedEvent = {
-  (event: typeof ADDRESS_SELECTED_EVENT, address: Address | null): void;
-};
-export type AddressEventPayload = {
-  detail: Address & {appIdentifier: string | undefined};
-};
 export type ValidationErrors = NonNullable<ProblemDetailsBadRequest['errors']>;
-
-/** Define-once, prevents unique instances of this data per component instance */
-const countryCode = useConfig().country;
-const postalCode: Ref<string | undefined> = ref();
-const houseNumber: Ref<string | undefined> = ref();
-const houseNumberSuffix: Ref<string | undefined> = ref();
-const street: Ref<string | undefined> = ref();
-const city: Ref<string | undefined> = ref();
-
-// Stores the full address for actual usage by consuming plugins/forms
-const selectedAddress: Ref<Address | undefined> = ref();
-
-// Contains both API and user input validation errors
-const validationErrors: Ref<ValidationErrors> = ref([]);
 
 /**
  * Provides reactive properties and methods for storing address data.
  * @param emit Provide an event emitter to emit events when the selected address changes. If empty, no events will be emitted.
  * @returns
  */
-export function useAddressData(emit?: AddressSelectedEvent) {
-  /**
-   * Reset the form and stored address data.
-   */
-  const doReset = () => {
-    selectedAddress.value = undefined;
-    postalCode.value = undefined;
-    houseNumber.value = undefined;
-    houseNumberSuffix.value = undefined;
-    street.value = undefined;
-    city.value = undefined;
-  };
+export const [useProvideAddressData, useAddressData] = createInjectionState(
+  () => {
+    const {country: countryCode} = useOrThrow(useConfig, 'useConfig');
+    const postalCode: Ref<string | undefined> = ref();
+    const houseNumber: Ref<string | undefined> = ref();
+    const houseNumberSuffix: Ref<string | undefined> = ref();
+    const street: Ref<string | undefined> = ref();
+    const city: Ref<string | undefined> = ref();
 
-  /**
-   * Override both user input and the emitted address with incoming data.
-   */
-  const selectAddress = (address: Address) => {
-    selectedAddress.value = address;
-    postalCode.value = address.postalCode;
-    houseNumber.value = address.houseNumber;
-    houseNumberSuffix.value = address.houseNumberSuffix;
-    street.value = address.street;
-    city.value = address.city;
-  };
+    // Stores the full address for actual usage by consuming plugins/forms
+    const selectedAddress: Ref<Address | undefined> = ref();
 
-  /**
-   * We use different kinds of lookups in NL (PostalCode-based) and rest-of world.
-   * This is a basic validator on whether we can do a lookup based on postal code and house number.
-   */
-  function hasRequiredPostalcodeLookupAttributes(data: {
-    countryCode: Ref<Alpha2CountryCode | undefined>;
-    postalCode: Ref<string | undefined>;
-    houseNumber: Ref<string | undefined>;
-  }): data is {
-    countryCode: Ref<'NL'>;
-    postalCode: Ref<string>;
-    houseNumber: Ref<string>;
-  } {
-    return (
-      toValue(data.countryCode) === 'NL' &&
-      (toValue(data.postalCode)?.length ?? 0) >= POSTAL_CODE_MIN_LENGTH &&
-      (toValue(data.houseNumber)?.length ?? 0) > 0
-    );
-  }
+    // Contains both API and user input validation errors
+    const validationErrors: Ref<ValidationErrors> = ref([]);
 
-  /**
-   * Computed property to check if we have all the required data to do a postal code lookup.
-   * This is slightly duplicated with the typeguard above -- using this computed is only possible in situations where the data should not need to be typed afterwards.
-   */
-  const isReadyForPostalCodeLookup = computed<boolean>(() => {
-    return hasRequiredPostalcodeLookupAttributes({
+    /**
+     * Reset the form and stored address data.
+     */
+    const doReset = () => {
+      selectedAddress.value = undefined;
+      postalCode.value = undefined;
+      houseNumber.value = undefined;
+      houseNumberSuffix.value = undefined;
+      street.value = undefined;
+      city.value = undefined;
+    };
+
+    /**
+     * Override both user input and the emitted address with incoming data.
+     */
+    const selectAddress = (address: Address) => {
+      selectedAddress.value = address;
+      postalCode.value = address.postalCode;
+      houseNumber.value = address.houseNumber;
+      houseNumberSuffix.value = address.houseNumberSuffix;
+      street.value = address.street;
+      city.value = address.city;
+    };
+
+    /**
+     * We use different kinds of lookups in NL (PostalCode-based) and rest-of world.
+     * This is a basic validator on whether we can do a lookup based on postal code and house number.
+     */
+    function hasRequiredPostalcodeLookupAttributes(data: {
+      countryCode: Ref<Alpha2CountryCode | undefined>;
+      postalCode: Ref<string | undefined>;
+      houseNumber: Ref<string | undefined>;
+    }): data is {
+      countryCode: Ref<'NL'>;
+      postalCode: Ref<string>;
+      houseNumber: Ref<string>;
+    } {
+      return (
+        toValue(data.countryCode) === 'NL' &&
+        (toValue(data.postalCode)?.length ?? 0) >= POSTAL_CODE_MIN_LENGTH &&
+        (toValue(data.houseNumber)?.length ?? 0) > 0
+      );
+    }
+
+    /**
+     * Computed property to check if we have all the required data to do a postal code lookup.
+     * This is slightly duplicated with the typeguard above -- using this computed is only possible in situations where the data should not need to be typed afterwards.
+     */
+    const isReadyForPostalCodeLookup = computed<boolean>(() => {
+      return hasRequiredPostalcodeLookupAttributes({
+        countryCode,
+        postalCode,
+        houseNumber,
+      });
+    });
+
+    /**
+     * Reset most of the state when the country changes.
+     */
+    watch(countryCode, () => {
+      doReset();
+    });
+
+    return {
       countryCode,
       postalCode,
       houseNumber,
-    });
-  });
-
-  /**
-   * Reset most of the state when the country changes.
-   */
-  watch(countryCode, () => {
-    doReset();
-  });
-
-  // Emit an event whenever selectedAddress changes, as this will be relevant to watch for changes in consiming plugins/forms
-  if (emit) {
-    watch(selectedAddress, (address) => {
-      emit(ADDRESS_SELECTED_EVENT, address || null);
-
-      document.dispatchEvent(
-        new CustomEvent(ADDRESS_SELECTED_EVENT, {
-          detail: {
-            ...address,
-            appIdentifier: toValue(useConfig().appIdentifier),
-          },
-        } as AddressEventPayload),
-      );
-    });
-  }
-
-  return {
-    countryCode,
-    postalCode,
-    houseNumber,
-    houseNumberSuffix,
-    street,
-    city,
-    selectedAddress,
-    doReset,
-    selectAddress,
-    hasRequiredPostalcodeLookupAttributes,
-    isReadyForPostalCodeLookup,
-    validationErrors,
-  };
-}
+      houseNumberSuffix,
+      street,
+      city,
+      selectedAddress,
+      doReset,
+      selectAddress,
+      hasRequiredPostalcodeLookupAttributes,
+      isReadyForPostalCodeLookup,
+      validationErrors,
+    };
+  },
+);

--- a/src/composables/useApiClient.spec.ts
+++ b/src/composables/useApiClient.spec.ts
@@ -1,30 +1,67 @@
-import {useConfig} from '@/composables/useConfig';
-import {it, expect} from 'vitest';
+import {vi, it, expect, describe, beforeEach} from 'vitest';
 import {useApiClient} from './useApiClient';
+import {withSetup} from '../../tests/withSetup';
+import {useProvideConfig} from './useConfig';
+import {nextTick} from 'vue';
 
-it('throws an error when the api url is not set', () => {
-  // Set empty config
-  const {configuration} = useConfig();
-  configuration.apiUrl = '';
-  expect(() => useApiClient()).toThrowError(
-    'Cannot init API: API URL is not set',
-  );
-});
+describe('useApiClient', () => {
+  let config: ReturnType<typeof useProvideConfig>;
+  let apiClient: ReturnType<typeof useApiClient>;
 
-it('throws an error when the api key is not set and the api url is the default', () => {
-  const {configuration} = useConfig();
-  configuration.apiKey = '';
-  configuration.apiUrl = 'https://address.api.myparcel.nl';
-  expect(() => useApiClient()).toThrowError(
-    'An API key must be set when using the default API URL',
-  );
-});
+  beforeEach(() => {
+    [[config, apiClient]] = withSetup(useProvideConfig, useApiClient);
+  });
 
-it('sets the base url on the client', () => {
-  const {configuration} = useConfig();
-  configuration.apiKey = '';
-  configuration.apiUrl = 'https://foo-bar';
+  it('logs an error when the api url is not set', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
 
-  const {client} = useApiClient();
-  expect(client.getConfig().baseUrl).toBe('https://foo-bar');
+    // Set empty config
+    const {configuration} = config;
+    configuration.apiUrl = '';
+
+    // Wait for the next tick, so the client is configured
+    await nextTick();
+
+    expect(console.error).toHaveBeenCalledWith(
+      'Cannot init API: API URL is not set',
+    );
+  });
+
+  it('logs an error when the api key is not set and the api url is the default', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const {configuration} = config;
+    configuration.apiKey = '';
+    configuration.apiUrl = 'https://address.api.myparcel.nl';
+
+    // Wait for the next tick, so the client is configured
+    await nextTick();
+
+    expect(console.error).toHaveBeenCalledWith(
+      'An API key must be set when using the default API URL',
+    );
+  });
+
+  it('does not an error when the api key is not set and the api url is the default', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const {configuration} = config;
+    configuration.apiKey = 'anApiKey';
+    configuration.apiUrl = 'https://address.api.myparcel.nl';
+
+    expect(console.error).toBeCalledTimes(0);
+  });
+
+  it('sets the base url on the client', async () => {
+    const {configuration} = config;
+    configuration.apiKey = '';
+    configuration.apiUrl = 'https://foo-bar';
+
+    const {client} = apiClient;
+
+    // Wait for the next tick, so the client is configured
+    await nextTick();
+
+    expect(client.getConfig().baseUrl).toBe('https://foo-bar');
+  });
 });

--- a/src/composables/useApiClient.spec.ts
+++ b/src/composables/useApiClient.spec.ts
@@ -42,7 +42,7 @@ describe('useApiClient', () => {
     );
   });
 
-  it('does not an error when the api key is not set and the api url is the default', async () => {
+  it('does not throw an error when the api key is not set and the api url is the default', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const {configuration} = config;

--- a/src/composables/useApiClient.ts
+++ b/src/composables/useApiClient.ts
@@ -1,39 +1,54 @@
 import {client} from '@/api-client/sdk.gen';
 import {useConfig, API_URL_DIRECT} from '@/composables/useConfig.ts';
-import {toValue} from 'vue';
+import {useOrThrow} from '@/utils/useOrThrow';
+import type {Client} from '@hey-api/client-fetch';
+import {toValue, watch} from 'vue';
 
 /**
  * Provides the API client instance with the correct configuration.
  */
 export function useApiClient() {
-  const {setConfigFromWindow, apiKey, apiUrl} = useConfig();
+  const {apiKey, apiUrl} = useOrThrow(useConfig, 'useConfig');
 
-  setConfigFromWindow();
-
-  if (!apiUrl.value?.length) {
-    throw new Error('Cannot init API: API URL is not set');
-  }
-
-  if (!apiKey.value && apiUrl.value === API_URL_DIRECT) {
-    throw new Error('An API key must be set when using the default API URL');
-  }
-
-  client.setConfig({
-    baseUrl: apiUrl.value,
-  });
-
-  client.interceptors.request.use((request) => {
-    if (toValue(apiKey)?.length) {
-      // Send the API key as a base64 encoded bearer token as per https://developer.myparcel.nl/api-reference/05.authentication.html
-      request.headers.set(
-        'Authorization',
-        `bearer ${btoa(<string>toValue(apiKey))}`,
-      );
+  const configureClient = (): Client => {
+    if (!apiUrl.value?.length) {
+      console.error('Cannot init API: API URL is not set');
+      return client;
     }
-    return request;
-  });
+
+    if (!apiKey.value && apiUrl.value === API_URL_DIRECT) {
+      console.error('An API key must be set when using the default API URL');
+    }
+
+    client.setConfig({
+      baseUrl: apiUrl.value,
+    });
+
+    if (toValue(apiKey)?.length) {
+      client.interceptors.request.use((request) => {
+        // Send the API key as a base64 encoded bearer token as per https://developer.myparcel.nl/api-reference/05.authentication.html
+        request.headers.set(
+          'Authorization',
+          `bearer ${btoa(<string>toValue(apiKey))}`,
+        );
+        return request;
+      });
+    }
+
+    return client;
+  };
+
+  // Automatically update the client when the API key or URL changes
+  watch(
+    [apiKey, apiUrl],
+    () => {
+      configureClient();
+    },
+    {immediate: false},
+  );
 
   return {
+    configureClient,
     client,
   };
 }

--- a/src/composables/useConfig.spec.ts
+++ b/src/composables/useConfig.spec.ts
@@ -1,4 +1,3 @@
-import {useConfig} from '@/composables/useConfig';
 import {describe} from 'node:test';
 import {it, expect, vi, beforeEach} from 'vitest';
 import {toValue} from 'vue';

--- a/src/composables/useConfig.spec.ts
+++ b/src/composables/useConfig.spec.ts
@@ -1,60 +1,70 @@
 import {useConfig} from '@/composables/useConfig';
-import {it, expect, vi} from 'vitest';
+import {describe} from 'node:test';
+import {it, expect, vi, beforeEach} from 'vitest';
 import {toValue} from 'vue';
+import {useProvideConfig} from './useConfig';
+import {withSetup} from '../../tests/withSetup';
 
-it('logs an errror but does not stop when given empty config objects', () => {
-  const {setConfig} = useConfig();
-  // Spy on the console...
-  console.error = vi.fn();
+describe('useConfig', () => {
+  let config: ReturnType<typeof useProvideConfig>;
+  beforeEach(() => {
+    [[config]] = withSetup(useProvideConfig);
+  });
 
-  expect(() => setConfig({})).not.toThrowError();
-  // Check there is an error in console
-  expect(console.error).toHaveBeenCalledWith(
-    'Invalid configuration:',
-    expect.objectContaining({
-      message: expect.stringContaining('Required'),
-    }),
-  );
-});
+  it('logs an errror but does not stop when given empty config objects', () => {
+    const {setConfig} = config;
+    // Spy on the console...
+    console.error = vi.fn();
 
-it('only sets a valid country code', () => {
-  const {setConfig, country} = useConfig();
-  const input = {
-    apiUrl: 'https://foo-bar',
-    country: 'NOTACOUNTRY',
-  };
-  expect(() => setConfig(input)).not.toThrowError();
-  expect(toValue(country)).toBe(undefined);
+    expect(() => setConfig({})).not.toThrowError();
+    // Check there is an error in console
+    expect(console.error).toHaveBeenCalledWith(
+      'Invalid configuration:',
+      expect.objectContaining({
+        message: expect.stringContaining('Required'),
+      }),
+    );
+  });
 
-  input.country = 'NL';
-  setConfig(input);
-  expect(toValue(country)).toBe('NL');
-});
+  it('only sets a valid country code', () => {
+    const {setConfig, country} = config;
+    const input = {
+      apiUrl: 'https://foo-bar',
+      country: 'NOTACOUNTRY',
+    };
+    expect(() => setConfig(input)).not.toThrowError();
+    expect(toValue(country)).toBe(undefined);
 
-it('sets valid data from the config object', () => {
-  const {setConfig, apiKey, apiUrl, country} = useConfig();
-  const input = {
-    apiKey: 'FUBAR',
-    apiUrl: 'https://foo-bar',
-    country: 'DK',
-  };
-  setConfig(input);
-  expect(toValue(apiKey)).toBe(input.apiKey);
-  expect(toValue(apiUrl)).toBe(input.apiUrl);
-  expect(toValue(country)).toBe(input.country);
-});
+    input.country = 'NL';
+    setConfig(input);
+    expect(toValue(country)).toBe('NL');
+  });
 
-it('sets valid data from the window object', () => {
-  const {setConfigFromWindow, apiKey, apiUrl, country} = useConfig();
-  const input = {
-    apiKey: 'FUBAR',
-    apiUrl: 'https://foo-bar',
-    country: 'DK',
-  };
+  it('sets valid data from the config object', () => {
+    const {setConfig, apiKey, apiUrl, country} = config;
+    const input = {
+      apiKey: 'FUBAR',
+      apiUrl: 'https://foo-bar',
+      country: 'DK',
+    };
+    setConfig(input);
+    expect(toValue(apiKey)).toBe(input.apiKey);
+    expect(toValue(apiUrl)).toBe(input.apiUrl);
+    expect(toValue(country)).toBe(input.country);
+  });
 
-  window.MyParcelAddressConfig = input;
-  setConfigFromWindow();
-  expect(toValue(apiKey)).toBe(input.apiKey);
-  expect(toValue(apiUrl)).toBe(input.apiUrl);
-  expect(toValue(country)).toBe(input.country);
+  it('sets valid data from the window object', () => {
+    const {setConfigFromWindow, apiKey, apiUrl, country} = config;
+    const input = {
+      apiKey: 'FUBAR',
+      apiUrl: 'https://foo-bar',
+      country: 'DK',
+    };
+
+    window.MyParcelAddressConfig = input;
+    setConfigFromWindow();
+    expect(toValue(apiKey)).toBe(input.apiKey);
+    expect(toValue(apiUrl)).toBe(input.apiUrl);
+    expect(toValue(country)).toBe(input.country);
+  });
 });

--- a/src/composables/useConfig.ts
+++ b/src/composables/useConfig.ts
@@ -1,5 +1,6 @@
 import type {Alpha2CountryCode} from '@/api-client';
 import {zAlpha2CountryCode} from '@/api-client/zod.gen';
+import {createInjectionState} from '@vueuse/core';
 import {reactive, ref} from 'vue';
 import {z} from 'zod';
 
@@ -15,14 +16,13 @@ export const zConfigObject = z.object({
 });
 export type ConfigObject = z.infer<typeof zConfigObject>;
 
-// Define these refs here so they become globals (like a store)
-const apiKey = ref<string | null>(import.meta.env.VITE_API_KEY);
-const apiUrl = ref<string | null>(import.meta.env.API_URL || API_URL_DIRECT);
-const country = ref<Alpha2CountryCode | undefined>('NL');
-const appIdentifier = ref<string | undefined>();
-const configuration = reactive({apiKey, apiUrl, country});
+export const [useProvideConfig, useConfig] = createInjectionState(() => {
+  const apiKey = ref<string | null>(import.meta.env.VITE_API_KEY);
+  const apiUrl = ref<string>(import.meta.env.API_URL || API_URL_DIRECT);
+  const country = ref<Alpha2CountryCode | undefined>('NL');
+  const appIdentifier = ref<string | undefined>();
+  const configuration = reactive({apiKey, apiUrl, country});
 
-export function useConfig() {
   /**
    * Ensure incoming configuration is valid using zod.
    * @param config
@@ -46,7 +46,7 @@ export function useConfig() {
       console.error('Invalid configuration:', error);
     }
     apiKey.value = validatedConfig?.apiKey || null;
-    apiUrl.value = validatedConfig?.apiUrl || null;
+    apiUrl.value = validatedConfig?.apiUrl || API_URL_DIRECT;
     country.value = validatedConfig?.country;
     appIdentifier.value = validatedConfig?.appIdentifier;
   }
@@ -66,4 +66,4 @@ export function useConfig() {
     setConfig,
     setConfigFromWindow,
   };
-}
+});

--- a/src/composables/useHandleUserInput.ts
+++ b/src/composables/useHandleUserInput.ts
@@ -1,14 +1,15 @@
 import {ref, toValue} from 'vue';
 import {useDebounceFn} from '@vueuse/core';
-import {useAddressData, type AddressSelectedEvent} from './useAddressData';
+import {useAddressData} from './useAddressData';
 import {useAddressApi} from './useAddressApi';
+import {useOrThrow} from '@/utils/useOrThrow';
 
 export const REQUEST_DEBOUNCE_TIME = 150; // arbitrary debounce time for API requests
 
 /**
  * Contains nessecary logic for user input handling.
  */
-export function useHandleUserInput(emit?: AddressSelectedEvent) {
+export function useHandleUserInput() {
   /* State */
 
   // Whether the user is manually entering an address.
@@ -24,10 +25,10 @@ export function useHandleUserInput(emit?: AddressSelectedEvent) {
     selectAddress,
     hasRequiredPostalcodeLookupAttributes,
     validationErrors,
-  } = useAddressData(emit);
+  } = useOrThrow(useAddressData, 'useAddressData');
 
   const {isProblemDetailsBadRequest, fetchAddressByPostalCode, resetState} =
-    useAddressApi();
+    useOrThrow(useAddressApi, 'useAddressApi');
 
   /**
    * Respond to input on postal code and house number fields with an API response when appropiate.

--- a/src/composables/useOutgoingEvents.spec.ts
+++ b/src/composables/useOutgoingEvents.spec.ts
@@ -1,0 +1,39 @@
+import {useOutgoingEvents} from './useOutgoingEvents';
+import {Address} from '../api-client/types.gen';
+import {describe, expect, it, vi} from 'vitest';
+import {withSetup} from '../../tests/withSetup';
+import {useProvideConfig} from './useConfig';
+
+describe('useOutgoingEvents', () => {
+  it('should emit and dispatch the ADDRESS_SELECTED_EVENT', () => {
+    const emit = vi.fn();
+    const [[config, outgoingEvents]] = withSetup(
+      useProvideConfig,
+      useOutgoingEvents,
+    );
+    const {emitAddressChange} = outgoingEvents;
+
+    vi.spyOn(document, 'dispatchEvent');
+
+    const address: Address = {
+      postalCode: '1234AB',
+      houseNumber: '1',
+      houseNumberSuffix: 'A',
+      street: 'Main St',
+      city: 'Amsterdam',
+      countryCode: 'NL',
+      postOfficeBox: false,
+    };
+
+    emitAddressChange(address, emit);
+
+    const event = new CustomEvent('address-selected', {
+      detail: {...address, appIdentifier: config.appIdentifier},
+    });
+    expect(document.dispatchEvent).toHaveBeenCalledWith(event);
+
+    // Verify the emitted event
+    expect(emit).toHaveBeenCalledWith('address-selected', address);
+    expect(emit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/composables/useOutgoingEvents.ts
+++ b/src/composables/useOutgoingEvents.ts
@@ -1,0 +1,35 @@
+import {toValue} from 'vue';
+import type {Address} from '@/api-client';
+import {useConfig} from './useConfig';
+import {useOrThrow} from '@/utils/useOrThrow';
+
+export const ADDRESS_SELECTED_EVENT = 'address-selected';
+export type AddressSelectedEvent = {
+  (event: typeof ADDRESS_SELECTED_EVENT, address: Address | null): void;
+};
+export type AddressEventPayload = {
+  detail: Address & {appIdentifier: string | undefined};
+};
+
+export const useOutgoingEvents = () => {
+  const config = useOrThrow(useConfig, 'useConfig');
+  const emitAddressChange = (
+    address: Address | undefined,
+    emit: AddressSelectedEvent,
+  ) => {
+    emit(ADDRESS_SELECTED_EVENT, address || null);
+
+    document.dispatchEvent(
+      new CustomEvent(ADDRESS_SELECTED_EVENT, {
+        detail: {
+          ...address,
+          appIdentifier: toValue(config.appIdentifier),
+        },
+      } as AddressEventPayload),
+    );
+  };
+
+  return {
+    emitAddressChange,
+  };
+};

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -15,3 +15,10 @@ it('exports an uninitialized app', () => {
 it('exports the name of the address selected event', () => {
   expect(exports.ADDRESS_SELECTED_EVENT).toBeDefined();
 });
+
+it('does not share state between multiple instances', () => {
+  // const app1: typeof App = exports.default;
+  // const app2: typeof App = exports.default;
+  // Set some address data
+  // TODO: Can be done once the app responds to config change events
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,9 @@
  * This is the main module file used to export the Vue app and any functionality that should be available to the consuming application.
  */
 import App from './App.vue';
+import {ADDRESS_SELECTED_EVENT} from './composables/useOutgoingEvents';
 
 export default App;
 
 // Additional exports for typing etc.
-export * from './composables/useConfig';
-export * from './composables/useAddressData';
+export {ADDRESS_SELECTED_EVENT};

--- a/src/utils/useOrThrow.ts
+++ b/src/utils/useOrThrow.ts
@@ -1,0 +1,12 @@
+export function useOrThrow<T>(
+  useComposable: () => T | undefined,
+  name: string,
+): T {
+  const instance = useComposable();
+  if (instance == null) {
+    throw new Error(
+      `'${name}()' must be provided by 'useProvideX()' before using the composable directly. You likely forgot to do this in the setup() function of App.vue.'`,
+    );
+  }
+  return instance;
+}

--- a/tests/mocks/requests/handlers.ts
+++ b/tests/mocks/requests/handlers.ts
@@ -1,4 +1,8 @@
 import {toValue} from 'vue';
+import {useProvideConfig} from '@/composables/useConfig';
+import {delay, http, HttpResponse} from 'msw';
+
+import {withSetup} from '../../withSetup';
 import {MOCK_ADDRESSES} from '../data/addresses';
 import {
   type GetAddressesData,
@@ -6,10 +10,9 @@ import {
   type GetValidateData,
   type GetValidateResponse,
 } from './../../../src/api-client/types.gen';
-import {useConfig} from '@/composables/useConfig';
-import {delay, http, HttpResponse} from 'msw';
 
-const baseUrl = toValue(useConfig().apiUrl);
+const [[config]] = withSetup(useProvideConfig);
+const baseUrl = toValue(config.apiUrl);
 
 export const handlers = [
   http.all('*', async () => {

--- a/tests/withSetup.ts
+++ b/tests/withSetup.ts
@@ -1,0 +1,33 @@
+import type {AnyFn} from '@vueuse/core';
+import {createApp, type App} from 'vue';
+
+/**
+ * Wraps one or more composables inside the setup function of a Vue app instance.
+ * @param composables - An array of composable functions to be executed.
+ * @returns A tuple containing the results of the composables and the Vue app instance.
+ */
+export function withSetup<T extends AnyFn[]>(
+  ...composables: T
+): [TupleReturnTypes<T>, App] {
+  const results: TupleReturnTypes<T> = [] as TupleReturnTypes<T>;
+  const app = createApp({
+    setup() {
+      results.push(...composables.map((composable) => composable()));
+      // Suppress missing template warning
+      return () => {};
+    },
+  });
+  app.mount(document.createElement('div'));
+  return [results, app];
+}
+
+/**
+ * Utility type to infer the return types of a tuple of functions.
+ */
+type TupleReturnTypes<FunctionType extends AnyFn[]> = {
+  [ArrayIndex in keyof FunctionType]: FunctionType[ArrayIndex] extends (
+    ...args: unknown[]
+  ) => infer ReturnType
+    ? ReturnType
+    : never;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
       ]
     }
   },
-  "include": ["src/**/*", "tests"],
+  "include": ["src/**/*", "tests/**/*"],
   "exclude": [
     "**/*.snap",
     "**/*.spec.*",


### PR DESCRIPTION
move states outside of module (import) scope and inside of the composable itself, using a provide/inject wrapper to keep it global within each app instance

fixes INT-941