### PR TITLE
feat: allow overriding path/url and query parameters

### DIFF
--- a/src/composables/useApiClient.spec.ts
+++ b/src/composables/useApiClient.spec.ts
@@ -67,4 +67,36 @@ describe('useApiClient', () => {
 
     expect(client.getConfig().baseUrl).toBe('https://foo-bar');
   });
+
+  it('allows overriding the path and query params', async () => {
+    const {configuration} = config;
+    const originalOptions = {
+      query: {
+        bar: 'baz',
+      },
+      baseUrl: 'https://addres.api.myparcel.nl',
+      url: '/adresses',
+    };
+    const originalRequest = new Request(
+      'https://addres.api.myparcel.nl/adresses',
+    );
+    configuration.value.apiRequestOptions = {
+      '/adresses': {
+        query: {
+          foo: 'bar',
+        },
+        path: '/',
+      },
+    };
+
+    const {overrideRequestOptions} = apiClient;
+    const modifiedRequest = overrideRequestOptions(
+      originalRequest,
+      originalOptions,
+    );
+
+    expect(modifiedRequest.url).toBe(
+      'https://addres.api.myparcel.nl/?bar=baz&foo=bar',
+    );
+  });
 });

--- a/src/composables/useConfig.ts
+++ b/src/composables/useConfig.ts
@@ -12,9 +12,24 @@ export const zClassNames = z.object({
 export const zElements = z.object({
   fieldWrapper: z.string().optional(),
 });
+export const zRequestOptions = z.object({
+  query: z
+    .record(
+      z.string(), // key of the query parameter, ex. "action"
+      z.unknown(), // value of the query parameter, ex. "listAddresses"
+    )
+    .optional(),
+  path: z.string().optional(),
+});
 export const zConfigObject = z.object({
   apiKey: z.string().optional().nullable(),
   apiUrl: z.string().optional(),
+  apiRequestOptions: z
+    .record(
+      z.string(), // path to which the request options apply
+      zRequestOptions,
+    )
+    .optional(),
   locale: z.string().optional().nullable(),
   appIdentifier: z.string().optional().nullable(),
   classNames: zClassNames.optional(),
@@ -27,6 +42,7 @@ export const [useProvideConfig, useConfig] = createInjectionState(() => {
   const configuration = ref<ConfigObject>({
     apiKey: undefined,
     apiUrl: API_URL_DIRECT,
+    apiRequestOptions: undefined,
     appIdentifier: undefined,
     classNames: undefined,
     elements: undefined,


### PR DESCRIPTION
Allow overriding the path and query parameters for outgoing requests to facilitate an api proxy that does not use the same paths as the microservice endpoints. This mostly applies to the myparcel PDK