### PR TITLE
Feat: add input classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ import {TheAddressWidget} from '@myparcel/address-widget';
 </template>
 ```
 
+You can also pass optional CSS classes for the generated markup:
+
+```js
+const myConfig = {
+  classNames: {
+    fieldWrapper: ['form-row-wide'],
+    input: ['input-text'],
+  },
+};
+```
+
 ### Implementation
 
 The widget is a Vue component and can be used in both Vue and non-Vue projects. It is intended to be injected in an existing form, where you would need to add a collection point for the data emitted by this widget.

--- a/src/components/Base/BaseTextField.spec.ts
+++ b/src/components/Base/BaseTextField.spec.ts
@@ -1,0 +1,47 @@
+import {describe, expect, it} from 'vitest';
+import {defineComponent, ref, type PropType} from 'vue';
+import {mount} from '@vue/test-utils';
+import BaseTextField from '@/components/Base/BaseTextField.vue';
+import {type ConfigObject, useProvideConfig} from '@/composables/useConfig';
+
+const HostComponent = defineComponent({
+  components: {BaseTextField},
+  props: {
+    config: {
+      type: Object as PropType<ConfigObject>,
+      required: false,
+      default: undefined,
+    },
+  },
+  setup(props) {
+    const {setConfig} = useProvideConfig();
+    const model = ref('');
+
+    if (props.config) {
+      setConfig(props.config);
+    }
+
+    return {model};
+  },
+  template: '<BaseTextField v-model="model" class="existing-class" />',
+});
+
+describe('BaseTextField', () => {
+  it('applies configured input classes without dropping incoming classes', () => {
+    const wrapper = mount(HostComponent, {
+      props: {
+        config: {
+          classNames: {
+            input: ['input-text', 'theme-input'],
+          },
+        },
+      },
+    });
+
+    const input = wrapper.get('input');
+
+    expect(input.classes()).toContain('existing-class');
+    expect(input.classes()).toContain('input-text');
+    expect(input.classes()).toContain('theme-input');
+  });
+});

--- a/src/components/Base/BaseTextField.vue
+++ b/src/components/Base/BaseTextField.vue
@@ -1,11 +1,16 @@
 <template>
   <input
     v-model="model"
+    :class="configuration.classNames?.input"
     type="text" />
 </template>
 
 <script lang="ts" setup>
+import {useConfig} from '@/composables/useConfig';
+import {useOrThrow} from '@/utils/useOrThrow';
+
 const model = defineModel<string>();
+const {configuration} = useOrThrow(useConfig, 'useConfig');
 </script>
 
 <style scoped>

--- a/src/composables/useConfig.spec.ts
+++ b/src/composables/useConfig.spec.ts
@@ -67,11 +67,17 @@ describe('useConfig', () => {
     const input = {
       apiKey: 'FUBAR',
       apiUrl: 'https://foo-bar',
+      classNames: {
+        input: ['input-text'],
+      },
       address: {countryCode: 'DK'},
     };
     setConfig(input);
     expect(toValue(configuration).apiKey).toBe(input.apiKey);
     expect(toValue(configuration).apiUrl).toBe(input.apiUrl);
+    expect(toValue(configuration).classNames?.input).toEqual(
+      input.classNames.input,
+    );
     expect(toValue(configuration).address.countryCode).toBe(
       input.address.countryCode,
     );

--- a/src/composables/useConfig.ts
+++ b/src/composables/useConfig.ts
@@ -8,6 +8,7 @@ export const API_URL_DIRECT = 'https://address.api.myparcel.nl';
  */
 export const zClassNames = z.object({
   fieldWrapper: z.array(z.string()).optional(),
+  input: z.array(z.string()).optional(),
 });
 export const zElements = z.object({
   fieldWrapper: z.string().optional(),


### PR DESCRIPTION
## Summary
- add configurable input classes to the address widget
- keep the widget generic for integrations that need platform-specific classes
- add a rendering test and config test

INT-1466
